### PR TITLE
Added pipeline capabilities

### DIFF
--- a/redis_shard/pipeline.py
+++ b/redis_shard/pipeline.py
@@ -100,5 +100,5 @@ class Pipeline(object):
         elif method in ["blpop_in", "rpush_in"]:
             return functools.partial(self.__qop_in, method)
         else:
-            raise NotImplementedError("method '%s' cannot be sharded" % method)
+            raise NotImplementedError("method '%s' cannot be pipelined" % method)
 

--- a/redis_shard/shard.py
+++ b/redis_shard/shard.py
@@ -139,7 +139,7 @@ class RedisShardAPI(object):
         elif method in ["blpop_in", "rpush_in"]:
             return functools.partial(self.__qop_in, method)
         else:
-            raise NotImplementedError("method '%s' cannot be pipelined" % method)
+            raise NotImplementedError("method '%s' cannot be sharded" % method)
 
 
     #########################################


### PR DESCRIPTION
This adds a new class (Pipeline) that enables you to pipeline requests to a sharded Redis db. It will make multiple requests, however no more than 1 per shard server.

A pipeline is opened to each shard server as needed, and only when needed. That pipeline is then used for the commands to that server. Upon execution each server pipeline is executed and the results are joined back together into one list.
