### PR TITLE
fix python version check to work in python2 as well as python3

### DIFF
--- a/redis_shard/helpers.py
+++ b/redis_shard/helpers.py
@@ -37,8 +37,8 @@ def format_config(settings):
         _type = type(settings[0])
         if _type == dict:
             return settings
-        if (sys.version_info.major == 3 and _type in [str, bytes]) \
-                or (sys.version_info.major == 2 and _type in [str, unicode]):
+        if (sys.version_info[0] == 3 and _type in [str, bytes]) \
+                or (sys.version_info[0] == 2 and _type in [str, unicode]):
             for config in settings:
                 configs.append(parse_url(config))
         else:


### PR DESCRIPTION
sys.version_info data structure changes between python2 and python3.  Code as it exists breaks in python2.  This change should work for both.
