### PR TITLE
Allow for bytes based keys in Python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ you want to use multi-keys command such as ``sinter``), you should use Hash Tags
 The string in a braces of a key is the Hash Tag of the key. The hash of a Hash Tag will be treated the hash of the key.
 So, keys ``foo``, ``bar{foo}`` and ``b{foo}ar`` will be sotred in the same node.
 
-..note:: Hash Tags are not supported with ``bytes`` keys in Python 3.
+.. note:: Hash Tags are not supported with ``bytes`` keys in Python 3.
 
 Tag method
 ~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,8 @@ you want to use multi-keys command such as ``sinter``), you should use Hash Tags
 The string in a braces of a key is the Hash Tag of the key. The hash of a Hash Tag will be treated the hash of the key.
 So, keys ``foo``, ``bar{foo}`` and ``b{foo}ar`` will be sotred in the same node.
 
+..note:: Hash Tags are not supported with ``bytes`` keys in Python 3.
+
 Tag method
 ~~~~~~~~~~~
 

--- a/redis_shard/_compat.py
+++ b/redis_shard/_compat.py
@@ -48,8 +48,8 @@ else:
     imap = map
     izip = zip
     xrange = range
-    basestring = str
-    unicode = str
+    basestring = (str, bytes)
+    unicode = bytes
     bytes = bytes
     long = int
 

--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -63,3 +63,11 @@ class TestShard(unittest.TestCase):
         """)
         eq_(self.client.evalsha(sha, 1, 'test8', b('8')), b('OK'))
         eq_(self.client.get('test8'), b('8'))
+
+    def test_bytes_key(self):
+        sha = self.client.script_load("""
+            return redis.call('set', KEYS[1], ARGV[1])
+        """)
+        eq_(self.client.evalsha(sha, 1, b'test8', b('8')), b('OK'))
+        eq_(self.client.get(b'test8'), b('8'))
+


### PR DESCRIPTION
Both redis and redis-py allow for bytes based keys. Unfortunately the regex used for tags prevents that style of usage. This PR adds support for bytes based strings by bypassing the tags logic for Python 3 when the key is a bytes object.