### PR TITLE
Fix crc-32 calculation per Python docs

### DIFF
--- a/redis_shard/hashring.py
+++ b/redis_shard/hashring.py
@@ -15,7 +15,7 @@ from ._compat import xrange, b, long
 
 
 hash_methods = {
-    'crc32': zlib.crc32,
+    'crc32': lambda x: zlib.crc32(x) & 0xffffffff,
     'md5': lambda x: long(md5(x).hexdigest(), 16),
     'sha1': lambda x: long(sha1(x).hexdigest(), 16),
 }


### PR DESCRIPTION
Python 2 and 3 will get difference results from the `zlib.crc32` method per the note at

https://docs.python.org/2/library/zlib.html#zlib.crc32 and https://docs.python.org/3/library/zlib.html#zlib.crc32

This PR applies the bitmask that to return the same values across platforms and thus ensure consistent hashing across applications using different Python Versions.