### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,15 +5,15 @@ Redis Shard
    :target: https://travis-ci.org/zhihu/redis-shard
    :alt: Build Status
 
-.. image:: https://pypip.in/version/redis-shard/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/redis-shard.svg?style=flat
     :target: https://pypi.python.org/pypi/redis-shard
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/redis-shard/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/redis-shard.svg?style=flat
     :target: https://pypi.python.org/pypi/redis-shard
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/license/redis-shard/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/redis-shard.svg?style=flat
     :target: https://pypi.python.org/pypi/redis-shard
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20redis-shard))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `redis-shard`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.