### PR TITLE
Replaced cgi.parse_qsl with urllib.parse_qsl

### DIFF
--- a/redis_shard/url.py
+++ b/redis_shard/url.py
@@ -7,7 +7,7 @@ except ImportError:
     # python3
     from urllib.parse import unquote
     from urllib.parse import urlparse
-    from cgi import parse_qsl  # noqa
+    from urllib.parse import parse_qsl
 
 
 def _parse_url(url):


### PR DESCRIPTION
From py3.0, `cgi.parse_qsl` [was deprecated][1] in favor of `urllib.parse.parse_qs`.
In py3.8, it [was dropped][2].

[1]:https://docs.python.org/3.0/library/cgi.html#cgi.parse_qs
[2]:https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals