### PR TITLE
Made Redis URL parsing smarter

### DIFF
--- a/redis_shard/shard.py
+++ b/redis_shard/shard.py
@@ -46,7 +46,6 @@ class RedisShardAPI(object):
             sentinel = Sentinel(sentinel['hosts'], socket_timeout=sentinel.get('socket_timeout', 1))
         for server_config in servers:
             name = server_config.pop('name')
-            server_config["max_connections"] = int(server_config.get("max_connections", 100))
             if name in self.connections:
                 raise ValueError("server's name config must be unique")
             if sentinel:

--- a/redis_shard/url.py
+++ b/redis_shard/url.py
@@ -9,6 +9,8 @@ except ImportError:
     from urllib.parse import urlparse
     from urllib.parse import parse_qsl
 
+from redis.connection import URL_QUERY_ARGUMENT_PARSERS
+
 
 def _parse_url(url):
     scheme = urlparse(url).scheme
@@ -35,6 +37,10 @@ def _parse_url(url):
 def parse_url(url):
     scheme, host, port, user, password, db, query = _parse_url(url)
     assert scheme == 'redis'
+    for param, value in query.items():
+        if param in URL_QUERY_ARGUMENT_PARSERS:
+            parser = URL_QUERY_ARGUMENT_PARSERS[param]
+            query[param] = parser(value)
     return dict(host=host, port=port, password=password, db=db, **query)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=["redis_shard"],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['redis>=2.10.5'],
+    install_requires=['redis>=2.10.6'],
     tests_require=['Nose'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Since v2.10.6, An argument parser for Redis URL was added to redis-py.

```python
URL_QUERY_ARGUMENT_PARSERS = {
    'db': int,
    'socket_timeout': float,
    'socket_connect_timeout': float,
    'socket_keepalive': to_bool,
    'retry_on_timeout': to_bool,
    'max_connections': int,
    'health_check_interval': int,
    'ssl_check_hostname': to_bool,
}
```