### PR TITLE
Fix CI related to ZADD/ZINCRBY

### DIFF
--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -3,6 +3,7 @@
 import unittest
 from redis_shard.shard import RedisShardAPI
 from redis_shard._compat import b
+from redis import __version__ as REDIS_VERSION
 from nose.tools import eq_
 from .config import settings
 
@@ -27,8 +28,12 @@ class TestShard(unittest.TestCase):
         self.client.delete('test8')
 
     def test_zset(self):
-        self.client.zadd('testzset', 'first', 1)
-        self.client.zadd('testzset', 'second', 2)
+        if REDIS_VERSION.startswith('2.'):
+            self.client.zadd('testzset', 'first', 1)
+            self.client.zadd('testzset', 'second', 2)
+        else:
+            self.client.zadd('testzset', {'first': 1})
+            self.client.zadd('testzset', {'second': 2})
         self.client.zrange('testzset', 0, -1) == ['first', 'second']
 
     def test_list(self):

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -3,6 +3,7 @@
 import unittest
 from redis_shard.shard import RedisShardAPI
 from redis_shard._compat import b
+from redis import __version__ as REDIS_VERSION
 from nose.tools import eq_
 
 from .config import sentinel_settings
@@ -25,8 +26,12 @@ class TestSentinelShard(unittest.TestCase):
         self.client.delete('test8')
 
     def test_zset(self):
-        self.client.zadd('testzset', 'first', 1)
-        self.client.zadd('testzset', 'second', 2)
+        if REDIS_VERSION.startswith('2.'):
+            self.client.zadd('testzset', 'first', 1)
+            self.client.zadd('testzset', 'second', 2)
+        else:
+            self.client.zadd('testzset', {'first': 1})
+            self.client.zadd('testzset', {'second': 2})
         self.client.zrange('testzset', 0, -1) == ['first', 'second']
 
     def test_list(self):


### PR DESCRIPTION
Since v3.0.0, the arguments for `ZADD` and `ZINCRBY` was changed.

> * 3.0.0
>   BACKWARDS INCOMPATIBLE CHANGES
>     * ZINCRBY arguments 'value' and 'amount' have swapped order to match the
>       the Redis server. The new argument order is: keyname, amount, value.
>     * ZADD now requires all element names/scores be specified in a single
>       dictionary argument named mapping. This was required to allow the NX,
>       XX, CH and INCR options to be specified.

Ref: [Changelog](https://github.com/andymccurdy/redis-py/blob/15dafb1414f05ce24ef336fc539e06ad6a2b3d19/CHANGES#L250-L282)